### PR TITLE
Explicit Numpy Conversion

### DIFF
--- a/game_of_life.py
+++ b/game_of_life.py
@@ -1,26 +1,25 @@
-import numpy as np
 import pygame
 import jax
 import jax.numpy as jnp
 from jax.scipy.signal import convolve
 from functools import partial
-
+import numpy as np
 class Canvas(object):
     def __init__(self):
         self.screen = None
         self.clock = None
-
+        
     def render(self, image):
         width_px, height_px, _ = image.shape
-
+        
         if self.screen is None:
             pygame.init()
             pygame.display.init()
             self.screen = pygame.display.set_mode((width_px, height_px))
-
+            
         if self.clock is None:
             self.clock = pygame.time.Clock()
-
+        
         surface = pygame.surfarray.make_surface(np.asarray(image))
 
         assert self.screen is not None
@@ -33,7 +32,7 @@ class Canvas(object):
         if self.screen is not None:
             pygame.display.quit()
             pygame.quit()
-
+         
 @jax.jit
 def update(cells):
     counts = convolve(jnp.pad(cells, 1, mode='wrap'), jnp.array([

--- a/game_of_life.py
+++ b/game_of_life.py
@@ -10,19 +10,19 @@ class Canvas(object):
     def __init__(self):
         self.screen = None
         self.clock = None
-
+        
     def render(self, image):
         width_px, height_px, _ = image.shape
-
+        
         if self.screen is None:
             pygame.init()
             pygame.display.init()
             self.screen = pygame.display.set_mode((width_px, height_px))
-
+            
         if self.clock is None:
             self.clock = pygame.time.Clock()
-
-        surface = pygame.surfarray.make_surface(image)
+        
+        surface = pygame.surfarray.make_surface(image)                
 
         assert self.screen is not None
         self.screen.blit(surface, (0, 0))
@@ -34,7 +34,7 @@ class Canvas(object):
         if self.screen is not None:
             pygame.display.quit()
             pygame.quit()
-
+         
 @jax.jit
 def update(cells):
     counts = convolve(jnp.pad(cells, 1, mode='wrap'), jnp.array([

--- a/game_of_life.py
+++ b/game_of_life.py
@@ -1,5 +1,4 @@
-import os
-os.environ['CUDA_VISIBLE_DEVICES']=""
+import numpy as np
 import pygame
 import jax
 import jax.numpy as jnp
@@ -10,19 +9,19 @@ class Canvas(object):
     def __init__(self):
         self.screen = None
         self.clock = None
-        
+
     def render(self, image):
         width_px, height_px, _ = image.shape
-        
+
         if self.screen is None:
             pygame.init()
             pygame.display.init()
             self.screen = pygame.display.set_mode((width_px, height_px))
-            
+
         if self.clock is None:
             self.clock = pygame.time.Clock()
-        
-        surface = pygame.surfarray.make_surface(image)                
+
+        surface = pygame.surfarray.make_surface(np.asarray(image))
 
         assert self.screen is not None
         self.screen.blit(surface, (0, 0))
@@ -34,7 +33,7 @@ class Canvas(object):
         if self.screen is not None:
             pygame.display.quit()
             pygame.quit()
-         
+
 @jax.jit
 def update(cells):
     counts = convolve(jnp.pad(cells, 1, mode='wrap'), jnp.array([

--- a/game_of_life.py
+++ b/game_of_life.py
@@ -1,3 +1,5 @@
+import os
+os.environ['CUDA_VISIBLE_DEVICES']=""
 import pygame
 import jax
 import jax.numpy as jnp
@@ -8,19 +10,19 @@ class Canvas(object):
     def __init__(self):
         self.screen = None
         self.clock = None
-        
+
     def render(self, image):
         width_px, height_px, _ = image.shape
-        
+
         if self.screen is None:
             pygame.init()
             pygame.display.init()
             self.screen = pygame.display.set_mode((width_px, height_px))
-            
+
         if self.clock is None:
             self.clock = pygame.time.Clock()
-        
-        surface = pygame.surfarray.make_surface(image)                
+
+        surface = pygame.surfarray.make_surface(image)
 
         assert self.screen is not None
         self.screen.blit(surface, (0, 0))
@@ -32,7 +34,7 @@ class Canvas(object):
         if self.screen is not None:
             pygame.display.quit()
             pygame.quit()
-         
+
 @jax.jit
 def update(cells):
     counts = convolve(jnp.pad(cells, 1, mode='wrap'), jnp.array([


### PR DESCRIPTION
The code crashes if run on a CUDA GPU, with the following error.
Hello from the pygame community. https://www.pygame.org/contribute.html
Traceback (most recent call last):
  File "/home/user/path/temp/game_of_life.py", line 60, in <module>
    canvas.render(cells_to_image(cells))
  File "/home/user/path/temp/game_of_life.py", line 23, in render
    surface = pygame.surfarray.make_surface(image)#np.asarray(image))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/miniconda3/envs/env/lib/python3.12/site-packages/pygame/surfarray.py", line 124, in make_surface
    return pix_make_surface(array)
           ^^^^^^^^^^^^^^^^^^^^^^^
BufferError: INVALID_ARGUMENT: Python buffer protocol is only defined for CPU buffers.


The explicit numpy conversion fixes this.